### PR TITLE
Allow to overwrite base url and provide Guzzle config

### DIFF
--- a/lib/ApiClient/Http/Client.php
+++ b/lib/ApiClient/Http/Client.php
@@ -15,9 +15,9 @@ final class Client implements ClientInterface
 {
     private readonly GuzzleClient $guzzle;
 
-    public function __construct()
+    public function __construct(array $guzzleConfig = [])
     {
-        $this->guzzle = new GuzzleClient();
+        $this->guzzle = new GuzzleClient($guzzleConfig);
     }
 
     public function head(string $url, array $headers): Response

--- a/lib/ApiClient/TicketparkApiClient.php
+++ b/lib/ApiClient/TicketparkApiClient.php
@@ -23,7 +23,8 @@ class TicketparkApiClient
 
     public function __construct(
         private readonly string $apiKey,
-        private readonly string $apiSecret
+        private readonly string $apiSecret,
+        private readonly string $baseUrl = self::ROOT_URL,
     ) {
     }
 
@@ -147,7 +148,7 @@ class TicketparkApiClient
             $params = '?' . http_build_query($parameters);
         }
 
-        return self::ROOT_URL . $path . $params;
+        return $this->baseUrl . $path . $params;
     }
 
     private function getValidAccessToken(): string

--- a/test/ApiClient/TicketparkApiClientTest.php
+++ b/test/ApiClient/TicketparkApiClientTest.php
@@ -224,4 +224,29 @@ class TicketparkApiClientTest extends TestCase
         $this->apiClient->setUserCredentials('username', 'secret');
         $this->apiClient->generateTokens();
     }
+
+    public function testGetWithOverwrittenBaseUrl()
+    {
+        $httpClient = $this->prophet->prophesize(ClientInterface::class);
+        $httpClient->get(
+            'https://overwritten.ticketpark.ch/path?foo=bar',
+            [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'Authorization' => 'Bearer some-token'
+            ]
+        )
+            ->willReturn(new Response(200, '', []))
+            ->shouldBeCalledOnce();
+
+        $apiClient = new TicketparkApiClient(
+            'apiKey',
+            'apiSecret',
+            'https://overwritten.ticketpark.ch'
+        );
+
+        $apiClient->setClient($httpClient->reveal());
+        $apiClient->setAccessToken('some-token');
+        $apiClient->get('/path', ['foo' => 'bar']);
+    }
 }


### PR DESCRIPTION
Allows to overwrite API base url and to provide Guzzle config.
Helpful for API mocking or our internal usage with development API environments